### PR TITLE
weight conversion scripts

### DIFF
--- a/single_stage_detector/backbone-convertors/numpy-to-torch.py
+++ b/single_stage_detector/backbone-convertors/numpy-to-torch.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: requires pytorch to write output file, so run something like:
+# docker run --env PYTHONDONTWRITEBYTECODE=1 -v $(pwd):/scratch \
+#        --ipc=host nvcr.io/nvidia/pytorch:20.08-py3            \
+#        /scratch/numpy-to-torch.py /scratch/resnet34-333f7ec4.pickle  /scratch/resnet34-333f7ec4.pth
+
+import torch
+import pickle
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description="read in pickled numpy file and convert to pytorch .pth file")
+
+parser.add_argument('input_file', type=str, help='input pickled numpy file')
+parser.add_argument('output_file', type=str, help='output pytorch .pth file')
+parser.add_argument('--verbose', action='store_true',
+                    help='also print the list of layers and their sizes')
+
+conversion_dict = {
+    # use None instead of string for output_name to keep the layer from being outputted
+#    'input_name': 'output_name'
+}
+
+def convert_numpy_name_to_pytorch_name(name, shape):
+    # pytorch calls batch-norm beta and gamma, "bias" and "weight" respectively:
+    if len(shape) == 1:
+        name = name.replace("beta", "bias")
+        name = name.replace("gamma", "weight")
+
+    # use the input name as output name by default, but if we have an explicit
+    # mapping in the conversion_dict, then use it
+    return conversion_dict.get(name, name)
+    
+args = parser.parse_args()
+
+with open(args.input_file, 'rb') as numpy_file:
+    numpy_dict = pickle.load(numpy_file)
+
+output_dict = {}
+
+for input_name, value in numpy_dict.items():
+    output_name = convert_numpy_name_to_pytorch_name(input_name, value.shape)
+    if output_name is None:
+        continue
+    
+    if args.verbose:
+        print(input_name, output_name, value.shape)
+
+    output_dict[output_name] = torch.from_numpy(value)
+
+with open(args.output_file, 'wb') as out_file:
+    torch.save(output_dict, out_file)

--- a/single_stage_detector/backbone-convertors/tf-to-numpy.py
+++ b/single_stage_detector/backbone-convertors/tf-to-numpy.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# NOTE: requires TensorFlow to read input file, so run something like:
+# docker run --env PYTHONDONTWRITEBYTECODE=1 -v $(pwd):/scratch \
+#        --ipc=host nvcr.io/nvidia/tensorflow:20.08-tf1-py3            \
+#        /scratch/tf-to-numpy.py /scratch/model.ckpt-12345  /scratch/resnet34-333f7ec4.pickle
+
+
+# info about how to read tf chkpoints and convert them is based on
+# https://medium.com/huggingface/from-tensorflow-to-pytorch-265f40ef2a28
+
+import os
+import pickle
+from argparse import ArgumentParser
+
+import tensorflow as tf
+import numpy as np
+
+parser = ArgumentParser(description='read in TensorFlow checkpoint and convert to pickled dictionary of numpy arrays')
+
+parser.add_argument('input_file', type=str,
+                    help='input TensorFlow checkpoint name, usually something like "model.ckpt-12345"')
+parser.add_argument('output_file', type=str,
+                    help='name of output pickled python file with dictionary of numpy arrays')
+parser.add_argument('--verbose', action='store_true',
+                    help='also print the list of tensors and their sizes')
+
+args = parser.parse_args()
+
+tf_path=os.path.abspath(args.input_file)
+tf_vars = tf.train.list_variables(tf_path)
+
+output_dict = {}
+
+for name, shape in tf_vars:
+    if "Momentum" in name or "global_step" in name:
+        # ignore optimizer state, we just want model weights
+        continue
+
+    if "dense" in name:
+        # if we're just using a backbone then the dense-layer from the end of
+        # the original model is irrelevant (and huge), so leave it out of the
+        # pickle file
+        if args.verbose:
+            print("ignoring dense layer", name)
+        continue
+            
+    numpy_array = tf.train.load_variable(tf_path, name)
+    assert numpy_array.dtype == 'float32'
+    
+    if len(numpy_array.shape) == 4:
+        # tensorflow uses R,S,C,K, while everyone else uses K,C,R,S
+        numpy_array = np.transpose(numpy_array, (3, 2, 0, 1))
+
+    # TensorFlow uses unusual names for batchnorm running_mean and var, so
+    # convert to something more recognizable:
+    if len(numpy_array.shape) == 1:
+        if "moving" in name:
+            name = name.replace("moving", "running")
+        if "variance" in name:
+            name = name.replace("variance", "var")
+
+    output_dict[name] = numpy_array
+    if args.verbose:
+        print(name, output_dict[name].shape)
+
+with open(args.output_file, 'wb') as out_file:
+    pickle.dump(output_dict, out_file)

--- a/single_stage_detector/backbone-convertors/torch-to-numpy.py
+++ b/single_stage_detector/backbone-convertors/torch-to-numpy.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: requires pytorch to read input file, so run something like:
+# docker run --env PYTHONDONTWRITEBYTECODE=1 -v $(pwd):/scratch \
+#        --ipc=host nvcr.io/nvidia/pytorch:20.08-py3            \
+#        /scratch/torch-to-numpy.py /scratch/resnet34-333f7ec4.pth  /scratch/resnet34-333f7ec4.pickle
+
+import torch
+import pickle
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description="read in pytorch .pth file and convert to pickled dictionary of numpy arrays")
+
+parser.add_argument('input_file', type=str, help='input pytorch .pth file name')
+parser.add_argument('output_file', type=str, help='name of output pickled python file with dictionary of numpy arrays')
+parser.add_argument('--verbose', action='store_true',
+                    help='also print the list of tensors and their sizes')
+
+args = parser.parse_args()
+
+with open(args.input_file, 'rb') as pth_file:
+    pt = torch.load(pth_file)
+
+output_dict = {}
+
+for name, value in pt.items():
+    if "fc" in name:
+        # if we're just using a backbone then the fully connected layer from
+        # the end of the original model is irrelevant (and huge), so leave it
+        # out of the pickle file
+        if args.verbose:
+            print("ignoring fully connected layer", name)
+        continue
+        
+    numpy_array = value.data.numpy()
+    assert numpy_array.dtype == 'float32'
+
+    # pytorch uses unusual names for batchnorm beta and gamma, so convert to
+    # something more recognizable:
+    if len(numpy_array.shape) == 1:
+        if "bias" in name:
+            name = name.replace("bias", "beta")
+        if "weight" in name:
+            name = name.replace("weight", "gamma")
+
+    output_dict[name] = numpy_array
+
+    if args.verbose:
+        print(name, output_dict[name].shape)
+
+with open(args.output_file, 'wb') as out_file:
+    pickle.dump(output_dict, out_file)


### PR DESCRIPTION
To standardize the numpy-pickle files I made a couple of choices (based on most common choice between tf, pytorch, mxnet):

* Numpy weight tensors are stored KCRS (the pytorch and mxnet order) not RSCK (the tensorflow order)
* numpy batch-norm running means and variances are called `running_mean` and `running_var` (the pytorch and mxnet choice), not `moving_mean` and `moving_variance` (the tensorflow choice)
* numpy batch-norm beta and gamma are called `beta` and `gamma` (the tensorflow and mxnet choice) not `bias` and `weight` (the pytorch choice)

The `framework`-to-numpy scripts do the above conversions, and only the above conversions
The numpy-to-pytorch script does the reverse of the above conversions, and also has an optional `conversion_dict` that can be used to arbitrariliy rename any layer.

I don't have a numpy-to-tf script, but if there were one it should do the reverse of the above convserions, and also have the optional `conversion_dict`.
